### PR TITLE
X-86_64 support

### DIFF
--- a/meihdfs/extract/Makefile
+++ b/meihdfs/extract/Makefile
@@ -1,6 +1,6 @@
 # arch-tag: Makefile - basic CFLAGS - fileutils/DVDrecorder directory
 
-CFLAGS=-O3 -mtune=i686 -march=i486 -pipe
+CFLAGS += -mtune=native -march=i486 -m32 -pipe
 
 all: extract
 

--- a/meihdfs/extract/README
+++ b/meihdfs/extract/README
@@ -1,0 +1,10 @@
+README
+
+PRE-REQUISITES:     sudo apt-get install gcc-multilib
+
+SYNOPSIS:           A program to extract the MEIHDFS-V2.0 file system
+BUILD:              make
+RUN:                ./extract_meihdfs <source> <Destination>
+INSTALL in $PATH:   sudo make install
+INSTALL in package: make install PREFIX=/usr DESTDIR=$RPM_BUILD_ROOT
+


### PR DESCRIPTION
Made it a little easier for the novice user to compile in linux, included a readme for the `meihdfs/extract` directory, and modified the CPU to allow compile on VM's

Tested with 

Ubuntu 20.04, 22.04
5.16.0-kali7-amd64 

Note my assumption here

_I am assuming the intent is to run on an instruciton set as close to I386 as possible, I could be wrong though, but this definitley works on Modern VM's  on_