### PR TITLE
extract_meihdfs: added recovery and resume mode

### DIFF
--- a/meihdfs/README.txt
+++ b/meihdfs/README.txt
@@ -39,6 +39,11 @@ Therefore I recommend using a linux BootCD/system and dd_rescue.
 
 After creating the image, you are set to use my utility to recover your data.
 
+There is also a limited support for dealing with unreadable blocks without
+creating an image before using the -r1 option. It will skip these blocks
+and write zero bytes instead. This is behaves similar to interference with
+reception.
+
 Extracting the filesystem files
 ===============================
 Now the strategy on how to recover your remaining movie data largely depends

--- a/meihdfs/extract/Makefile
+++ b/meihdfs/extract/Makefile
@@ -1,6 +1,6 @@
 # arch-tag: Makefile - basic CFLAGS - fileutils/DVDrecorder directory
 
-CFLAGS += -mtune=native -march=i486 -m32 -pipe
+CFLAGS += -mtune=native -pipe
 
 all: extract
 

--- a/meihdfs/extract/extract_meihdfs.c
+++ b/meihdfs/extract/extract_meihdfs.c
@@ -47,6 +47,9 @@
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif
+#ifndef O_DIRECT
+#define O_DIRECT 0
+#endif
 #ifdef WIN32
 #define mkdir(x,y) mkdir(x)
 #endif
@@ -391,7 +394,7 @@ int main(int argc, char **argv)
 		single_sector = 1;
 	}
 
-	inst.fdd = open(argv[as], O_RDONLY|O_LARGEFILE|O_BINARY);
+	inst.fdd = open(argv[as], single_sector ? O_RDONLY|O_LARGEFILE|O_BINARY|O_DIRECT : O_RDONLY|O_LARGEFILE|O_BINARY);
 	if(inst.fdd == -1)
 	{
 		fprintf(stderr, "Error opening image %s:%s\n", argv[as], strerror(errno));

--- a/meihdfs/extract/extract_meihdfs.c
+++ b/meihdfs/extract/extract_meihdfs.c
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
 		fprintf (stderr, "Usage: %s [-s<Start>] [-r1] <Image> <Output dir>\n\n"
 		         "\t-s\tOptional hex offset where to start searching header\n"
 		         "\t\ti.e.: -s0xA4000000 \n"
-		         "\t-1\tUse single sector mode and continue on errors in video files\n", argv[0]);
+		         "\t-1\tUse single sector mode and continue on read errors in video files\n", argv[0]);
 		return -1;
 	}
 

--- a/udf/pana-udf/Makefile
+++ b/udf/pana-udf/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-O3 -mtune=i686 -march=i486 -pipe
+CFLAGS=-O3 -pipe
 
 all: udf_dump
 


### PR DESCRIPTION
I made some improvements to the MEIHDFS extractor.

1. A **data recovery mode** (option -r1) witch will read physical sectors one by one and continue on read errors.
   This might be faster than creating a disk image since it avoids reading unallocated storage and it requires significantly less temporary storage.
   Last but not least errors can be associated with the damaged recordings using the stderr output.
2. **Automatically resume** if an extraction was interrupted before for some reason.
   Completely dumped files are simply skipped.
3. Do not write to stderr and stdout alternately.
   This causes changes in the output sequence and error messages might appear in the wrong context.
4. Avoid compiler warnings due to incorrect printf format strings using C99 size specifiers, i.e z for size_t and j for off64_t.
5. Remove plattform specific options in Makefile.
   They cause a build break on other platforms.